### PR TITLE
Bash script for pcntl module instalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# scripts-ubuntu
+Scripts Ubuntu
+==============
+
 Uma coleção de scripts para instalar softwares diretamente pelo cli
+
+# install-pcntl.bash
+
+Bash script para a instalação do módulo pcntl do php. 
+
+Só rode ele como sudo ou root.

--- a/install-pcntl.bash
+++ b/install-pcntl.bash
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+#
+# Script para a habilitação do módulo pcntl do php
+#
+
+if [ "$EUID" -ne 0 ]
+  then echo "Rode com sudo, ou como root"
+  exit
+fi
+
+TMP=/tmp/phpsource
+PHP_MODULE_INI=/etc/php5/mods-available/pcntl.ini
+
+echo "Creating temp dirs"
+
+if [ ! -d $TMP ]; then
+    mkdir $TMP
+fi
+
+cd $TMP
+
+if [ ! -d $TMP/php5* ]; then
+    echo "Getting the php source"
+    apt-get source php5
+else
+   echo "Already has the source"
+fi
+
+cd $TMP/php5-*/ext/pcntl
+
+echo "Phpizing..."
+phpize
+
+echo "Configuring..."
+./configure
+
+echo "Making..."
+make
+
+echo "Installing module"
+
+if [ ! -e $PHP_MODULE_BIN ]; then
+    cd modules
+    cp pcntl.so /usr/lib/php5/20131106/pcntl.so
+else
+    echo "Already has compiled lib"
+fi
+
+if [ ! -e $PHP_MODULE_INI ]; then
+    echo "extension=pcntl.so" > $PHP_MODULE_INI
+else
+    echo "Already has $PHP_MODULE_INI"
+fi
+
+echo "Enabling module"
+php5enmod pcntl
+
+echo "Restart fpm"
+
+# CHANGE THIS IF USING mod_php
+service php5-fpm restart
+
+echo "Cleaning..."
+rm -Rf $TMP

--- a/permission-www.sh
+++ b/permission-www.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+
 sudo groupadd www-pub
 sudo usermod -a -G www-pub root
-sudo usermod -a -G www-pub reinaldo
+sudo usermod -a -G www-pub $USER
 sudo usermod -a -G www-pub www-data
-sudo chown -R reinaldo:www-pub /var/www
+sudo chown -R $USER:www-pub /var/www
 sudo chmod 2775 /var/www
 sudo find /var/www -type d -exec chmod 2775 {} +
 sudo find /var/www -type f -exec chmod 0664 {} +

--- a/permission-www.sh
+++ b/permission-www.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 sudo groupadd www-pub
 sudo usermod -a -G www-pub root
-sudo usermod -a -G www-pub rubens
+sudo usermod -a -G www-pub reinaldo
 sudo usermod -a -G www-pub www-data
-sudo chown -R root:www-pub /var/www
+sudo chown -R reinaldo:www-pub /var/www
 sudo chmod 2775 /var/www
 sudo find /var/www -type d -exec chmod 2775 {} +
 sudo find /var/www -type f -exec chmod 0664 {} +


### PR DESCRIPTION
Here, a script to install pcntl module ubuntu and derivated boxes. May work in every apt-get (aptitude) dependant, need to test.

Updated also the permissions-www, to work with the current logged user so user doesn't need to change the script
